### PR TITLE
add semantic adapter document

### DIFF
--- a/docs/adapters/semantic_adapters.md
+++ b/docs/adapters/semantic_adapters.md
@@ -1,0 +1,217 @@
+# Semantic Adapters
+
+Datus Agent supports connecting to various semantic layer services through a plugin-based adapter system. This document explains the available adapters, how to install them, and how to configure semantic layer connections.
+
+## Overview
+
+Datus uses a modular semantic adapter architecture that allows you to connect to different semantic layer backends:
+
+- **MetricFlow**: dbt's semantic layer for metrics and dimensions
+
+This design provides a unified interface for metric discovery, querying, and validation across different semantic layer implementations.
+
+## Architecture
+
+```text
+datus-agent (Core)
+├── Semantic Tools Layer
+│   ├── BaseSemanticAdapter (Abstract)
+│   ├── SemanticAdapterRegistry (Factory)
+│   └── Data Models (MetricDefinition, QueryResult, etc.)
+│
+└── Plugin System (Entry Points)
+    └── datus-semantic-metricflow
+        └── MetricFlowAdapter
+```
+
+The adapter system uses Python's entry points mechanism for automatic discovery. When you install an adapter package, it registers itself with Datus Agent and becomes available for use.
+
+## Supported Semantic Layers
+
+| Semantic Layer | Package | Installation | Status |
+|----------------|---------|-------------|--------|
+| MetricFlow | datus-semantic-metricflow | `pip install datus-semantic-metricflow` | Ready |
+
+## Installation
+
+### MetricFlow Adapter
+
+```bash
+# Install MetricFlow adapter
+pip install datus-semantic-metricflow
+
+# Or install from source
+pip install -e ../datus-semantic-adapter/datus_semantic_metricflow
+```
+
+Once installed, Datus Agent will automatically detect and load the adapter.
+
+## Configuration
+
+Configure your semantic layer in the `config.yaml` file under the `semantic` section:
+
+### MetricFlow
+
+```yaml
+semantic:
+  type: metricflow
+  namespace: my_project
+  timeout: 300  # optional, default is 300 seconds
+  config_path: /path/to/agent.yml  # optional, uses default lookup if not specified
+```
+
+**Semantic Model File Location**:
+MetricFlow automatically locates semantic model files at:
+```
+{agent.home}/semantic_models/{namespace}/
+```
+- `agent.home` is read from `agent.yml` (defaults to `~/.datus`)
+
+### Configuration Lookup Priority
+
+When initializing MetricFlow adapter:
+
+1. `config_path` parameter (if explicitly provided)
+2. `./conf/agent.yml` (current directory)
+3. `~/.datus/conf/agent.yml` (home directory)
+
+## Core Interfaces
+
+### Metrics Interface
+
+All semantic adapters implement these core async methods:
+
+| Method | Description | Return Type |
+|--------|-------------|-------------|
+| `list_metrics(path, limit, offset)` | List available metrics with filtering | `List[MetricDefinition]` |
+| `get_dimensions(metric_name, path)` | Get dimensions for a metric | `List[DimensionInfo]` |
+| `query_metrics(metrics, dimensions, ...)` | Query metrics with filters, time range, where clause | `QueryResult` |
+| `validate_semantic()` | Validate semantic layer configuration | `ValidationResult` |
+
+### Semantic Model Interface (Optional)
+
+| Method | Description | Return Type |
+|--------|-------------|-------------|
+| `get_semantic_model(table_name, ...)` | Get semantic model for a table | `Optional[Dict]` |
+| `list_semantic_models(...)` | List available semantic models | `List[str]` |
+
+## Data Models
+
+| Model | Key Fields |
+|-------|------------|
+| `MetricDefinition` | `name`, `description`, `type`, `dimensions`, `measures`, `unit`, `format`, `path` |
+| `QueryResult` | `columns`, `data`, `metadata` |
+| `ValidationResult` | `valid`, `issues` |
+| `ValidationIssue` | `severity`, `message`, `location` |
+| `DimensionInfo` | `name`, `description` |
+
+## Usage Examples
+
+### Direct Adapter Usage
+
+```python
+from datus.tools.semantic_tools import semantic_adapter_registry
+from datus_semantic_metricflow.config import MetricFlowConfig
+
+config = MetricFlowConfig(namespace="my_project")
+adapter = semantic_adapter_registry.create_adapter("metricflow", config)
+
+metrics = await adapter.list_metrics(limit=10)
+dimensions = await adapter.get_dimensions(metric_name="revenue")
+result = await adapter.query_metrics(
+    metrics=["revenue"], dimensions=["date"], time_start="2024-01-01"
+)
+```
+
+### Dry Run (SQL Preview)
+
+```python
+result = await adapter.query_metrics(metrics=["revenue"], dry_run=True)
+print(result.data[0]["sql"])
+```
+
+### Bootstrap from Adapter
+
+```bash
+datus-agent bootstrap-kb --namespace my_project --components metrics \
+  --from_adapter metricflow --kb-update-strategy overwrite
+```
+
+## Features by Adapter
+
+### Common Features
+
+All semantic adapters support:
+
+- Metric discovery and listing
+- Dimension retrieval per metric
+- Metric querying with filters
+- Configuration validation
+- Storage sync for caching
+
+### MetricFlow Adapter
+
+- Full MetricFlow API integration
+- YAML-based semantic model files
+- Three-stage validation (lint, parse, semantic)
+- SQL generation and explain
+- Time range filtering with granularity
+
+## Implementing a Custom Adapter
+
+You can implement your own semantic adapter by extending `BaseSemanticAdapter` and registering it via Python entry points.
+
+### Required Methods
+
+Your adapter must implement these abstract methods:
+
+| Method | Description | Return Type |
+|--------|-------------|-------------|
+| `list_metrics()` | List available metrics with optional filtering | `List[MetricDefinition]` |
+| `get_dimensions()` | Get queryable dimensions for a metric | `List[DimensionInfo]` |
+| `query_metrics()` | Execute metric queries with filters | `QueryResult` |
+| `validate_semantic()` | Validate semantic layer configuration | `ValidationResult` |
+
+### Optional Methods
+
+| Method | Description | Default |
+|--------|-------------|---------|
+| `get_semantic_model()` | Get semantic model for a table | Returns `None` |
+| `list_semantic_models()` | List available semantic models | Returns `[]` |
+
+### Package Structure
+
+```
+datus_semantic_myservice/
+├── pyproject.toml
+└── datus_semantic_myservice/
+    ├── __init__.py    # register() function
+    ├── adapter.py     # MyServiceAdapter
+    └── config.py      # MyServiceConfig
+```
+
+### Entry Point Configuration
+
+```toml
+# pyproject.toml
+[project.entry-points."datus.semantic_adapters"]
+myservice = "datus_semantic_myservice:register"
+```
+
+### Reference Implementation
+
+See the MetricFlow adapter implementation for a complete example:
+- [datus-semantic-metricflow](https://github.com/Datus-ai/datus-semantic-adapter)
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Adapter not found | Install the adapter: `pip install datus-semantic-metricflow` |
+| Connection issues | Verify `agent.yml` config, check namespace matches semantic model directory |
+| Validation errors | Run `adapter.validate_semantic()` to check configuration |
+
+## Next Steps
+
+- [MetricFlow Configuration](../metricflow/introduction.md) - Detailed MetricFlow setup
+- [Configuration Reference](../configuration/introduction.md) - General configuration options

--- a/docs/adapters/semantic_adapters.zh.md
+++ b/docs/adapters/semantic_adapters.zh.md
@@ -1,0 +1,217 @@
+# 语义层适配器
+
+Datus Agent 通过插件化的适配器系统支持连接各种语义层服务。本文档介绍可用的适配器、安装方法以及语义层连接配置。
+
+## 概述
+
+Datus 采用模块化的语义层适配器架构，支持连接不同的语义层后端：
+
+- **MetricFlow**: dbt 的语义层，用于指标和维度管理
+
+这种设计为不同的语义层实现提供了统一的指标发现、查询和验证接口。
+
+## 架构
+
+```text
+datus-agent (核心)
+├── 语义层工具层
+│   ├── BaseSemanticAdapter (抽象基类)
+│   ├── SemanticAdapterRegistry (工厂)
+│   └── 数据模型 (MetricDefinition, QueryResult 等)
+│
+└── 插件系统 (Entry Points)
+    └── datus-semantic-metricflow
+        └── MetricFlowAdapter
+```
+
+适配器系统使用 Python 的 entry points 机制进行自动发现。安装适配器包后，它会自动注册到 Datus Agent 并可供使用。
+
+## 支持的语义层
+
+| 语义层 | 包名 | 安装方式 | 状态 |
+|--------|------|---------|------|
+| MetricFlow | datus-semantic-metricflow | `pip install datus-semantic-metricflow` | 可用 |
+
+## 安装
+
+### MetricFlow 适配器
+
+```bash
+# 安装 MetricFlow 适配器
+pip install datus-semantic-metricflow
+
+# 或从源码安装
+pip install -e ../datus-semantic-adapter/datus_semantic_metricflow
+```
+
+安装后，Datus Agent 会自动检测并加载适配器。
+
+## 配置
+
+在 `config.yaml` 文件的 `semantic` 部分配置语义层：
+
+### MetricFlow
+
+```yaml
+semantic:
+  type: metricflow
+  namespace: my_project
+  timeout: 300  # 可选，默认 300 秒
+  config_path: /path/to/agent.yml  # 可选，未指定时使用默认查找路径
+```
+
+**语义模型文件位置**：
+MetricFlow 自动在以下位置查找语义模型文件：
+```
+{agent.home}/semantic_models/{namespace}/
+```
+- `agent.home` 从 `agent.yml` 读取（默认为 `~/.datus`）
+
+### 配置查找优先级
+
+初始化 MetricFlow 适配器时：
+
+1. `config_path` 参数（如果显式提供）
+2. `./conf/agent.yml`（当前目录）
+3. `~/.datus/conf/agent.yml`（主目录）
+
+## 核心接口
+
+### 指标接口
+
+所有语义层适配器实现以下核心异步方法：
+
+| 方法 | 描述 | 返回类型 |
+|------|------|---------|
+| `list_metrics(path, limit, offset)` | 列出可用指标，支持过滤 | `List[MetricDefinition]` |
+| `get_dimensions(metric_name, path)` | 获取指标的维度 | `List[DimensionInfo]` |
+| `query_metrics(metrics, dimensions, ...)` | 查询指标，支持过滤、时间范围、where 子句 | `QueryResult` |
+| `validate_semantic()` | 验证语义层配置 | `ValidationResult` |
+
+### 语义模型接口（可选）
+
+| 方法 | 描述 | 返回类型 |
+|------|------|---------|
+| `get_semantic_model(table_name, ...)` | 获取表的语义模型 | `Optional[Dict]` |
+| `list_semantic_models(...)` | 列出可用的语义模型 | `List[str]` |
+
+## 数据模型
+
+| 模型 | 主要字段 |
+|------|---------|
+| `MetricDefinition` | `name`, `description`, `type`, `dimensions`, `measures`, `unit`, `format`, `path` |
+| `QueryResult` | `columns`, `data`, `metadata` |
+| `ValidationResult` | `valid`, `issues` |
+| `ValidationIssue` | `severity`, `message`, `location` |
+| `DimensionInfo` | `name`, `description` |
+
+## 使用示例
+
+### 直接使用适配器
+
+```python
+from datus.tools.semantic_tools import semantic_adapter_registry
+from datus_semantic_metricflow.config import MetricFlowConfig
+
+config = MetricFlowConfig(namespace="my_project")
+adapter = semantic_adapter_registry.create_adapter("metricflow", config)
+
+metrics = await adapter.list_metrics(limit=10)
+dimensions = await adapter.get_dimensions(metric_name="revenue")
+result = await adapter.query_metrics(
+    metrics=["revenue"], dimensions=["date"], time_start="2024-01-01"
+)
+```
+
+### Dry Run（SQL 预览）
+
+```python
+result = await adapter.query_metrics(metrics=["revenue"], dry_run=True)
+print(result.data[0]["sql"])
+```
+
+### 从适配器同步数据
+
+```bash
+datus-agent bootstrap-kb --namespace my_project --components metrics \
+  --from_adapter metricflow --kb-update-strategy overwrite
+```
+
+## 适配器功能
+
+### 通用功能
+
+所有语义层适配器支持：
+
+- 指标发现和列表
+- 按指标获取维度
+- 带过滤条件的指标查询
+- 配置验证
+- 存储同步缓存
+
+### MetricFlow 适配器
+
+- 完整的 MetricFlow API 集成
+- 基于 YAML 的语义模型文件
+- 三阶段验证（lint、parse、semantic）
+- SQL 生成和执行计划
+- 支持时间粒度的时间范围过滤
+
+## 实现自定义适配器
+
+你可以通过继承 `BaseSemanticAdapter` 并通过 Python entry points 注册来实现自己的语义层适配器。
+
+### 必须实现的方法
+
+你的适配器必须实现以下抽象方法：
+
+| 方法 | 描述 | 返回类型 |
+|------|------|---------|
+| `list_metrics()` | 列出可用指标，支持过滤 | `List[MetricDefinition]` |
+| `get_dimensions()` | 获取指标的可查询维度 | `List[DimensionInfo]` |
+| `query_metrics()` | 执行带过滤条件的指标查询 | `QueryResult` |
+| `validate_semantic()` | 验证语义层配置 | `ValidationResult` |
+
+### 可选方法
+
+| 方法 | 描述 | 默认行为 |
+|------|------|---------|
+| `get_semantic_model()` | 获取表的语义模型 | 返回 `None` |
+| `list_semantic_models()` | 列出可用的语义模型 | 返回 `[]` |
+
+### 包结构
+
+```
+datus_semantic_myservice/
+├── pyproject.toml
+└── datus_semantic_myservice/
+    ├── __init__.py    # register() 函数
+    ├── adapter.py     # MyServiceAdapter
+    └── config.py      # MyServiceConfig
+```
+
+### Entry Point 配置
+
+```toml
+# pyproject.toml
+[project.entry-points."datus.semantic_adapters"]
+myservice = "datus_semantic_myservice:register"
+```
+
+### 参考实现
+
+完整示例请参考 MetricFlow 适配器实现：
+- [datus-semantic-metricflow](https://github.com/Datus-ai/datus-semantic-adapter)
+
+## 故障排除
+
+| 问题 | 解决方案 |
+|------|---------|
+| 适配器未找到 | 安装适配器：`pip install datus-semantic-metricflow` |
+| 连接问题 | 验证 `agent.yml` 配置，检查 namespace 与语义模型目录匹配 |
+| 验证错误 | 运行 `adapter.validate_semantic()` 检查配置 |
+
+## 下一步
+
+- [MetricFlow 配置](../metricflow/introduction.md) - MetricFlow 详细配置
+- [配置参考](../configuration/introduction.md) - 通用配置选项

--- a/docs/getting_started/Quickstart.md
+++ b/docs/getting_started/Quickstart.md
@@ -543,5 +543,5 @@ Now that you're up and running with Datus, explore more advanced features:
 - **[Contextual Data Engineering](./contextual_data_engineering.md)** - Learn how to use data assets as context
 - **[Configuration Guide](../configuration/introduction.md)** - Connect to your own databases and customize settings
 - **[CLI Reference](../cli/introduction.md)** - Discover all available commands and options
-- **[MetricFlow](../metricflow/introduction.md)** - Generate and query metrics with datus-metricflow
+- **[Semantic Adapters](../adapters/semantic_adapters.md)** - Generate and query metrics with datus-semantic-metricflow
 

--- a/docs/getting_started/Quickstart.zh.md
+++ b/docs/getting_started/Quickstart.zh.md
@@ -543,7 +543,7 @@ Datus 会自动分析该表，并将元数据加入上下文。
 - **[上下文数据工程](./contextual_data_engineering.md)** —— 学习如何将数据资产用作上下文
 - **[配置指南](../configuration/introduction.md)** —— 连接自有数据库并自定义设置
 - **[CLI 参考手册](../cli/introduction.md)** —— 掌握全部命令与选项
-- **[MetricFlow](../metricflow/introduction.md)** —— 使用 datus-metricflow 构建与查询指标
+- **[语义层适配器](../adapters/semantic_adapters.md)** —— 使用 datus-semantic-metricflow 构建与查询指标
 
 
 

--- a/docs/knowledge_base/metrics.md
+++ b/docs/knowledge_base/metrics.md
@@ -46,7 +46,7 @@ This ensures consistent metric definitions across the organization.
 
 ## Usage
 
-**Prerequisites**: This command relies on [datus-metricflow](../metricflow/introduction.md), install it first.
+**Prerequisites**: This command relies on [datus-semantic-metricflow](../adapters/semantic_adapters.md), install it first with `pip install datus-semantic-metricflow`.
 
 ### Basic Command
 

--- a/docs/knowledge_base/metrics.zh.md
+++ b/docs/knowledge_base/metrics.zh.md
@@ -46,7 +46,7 @@ query_metrics(
 
 ## 使用方法
 
-**前置条件**：此命令依赖 [datus-metricflow](../metricflow/introduction.md)，请先安装。
+**前置条件**：此命令依赖 [datus-semantic-metricflow](../adapters/semantic_adapters.md)，请先运行 `pip install datus-semantic-metricflow` 安装。
 
 ### 基本命令
 

--- a/docs/knowledge_base/semantic_model.md
+++ b/docs/knowledge_base/semantic_model.md
@@ -42,7 +42,7 @@ Semantic model objects are stored at field level:
 
 ## Usage
 
-**Prerequisites**: This command relies on [datus-metricflow](../metricflow/introduction.md), install it first.
+**Prerequisites**: This command relies on [datus-semantic-metricflow](../adapters/semantic_adapters.md), install it first with `pip install datus-semantic-metricflow`.
 
 ### Basic Command
 

--- a/docs/knowledge_base/semantic_model.zh.md
+++ b/docs/knowledge_base/semantic_model.zh.md
@@ -42,7 +42,7 @@
 
 ## 使用方法
 
-**前置条件**：此命令依赖 [datus-metricflow](../metricflow/introduction.md)，请先安装。
+**前置条件**：此命令依赖 [datus-semantic-metricflow](../adapters/semantic_adapters.md)，请先运行 `pip install datus-semantic-metricflow` 安装。
 
 ### 基本命令
 

--- a/docs/metricflow/introduction.md
+++ b/docs/metricflow/introduction.md
@@ -40,6 +40,7 @@ datus-metricflow currently supports:
 
 - **DuckDB** - Embedded analytical database (great for demos and local development)
 - **SQLite** - Lightweight embedded database
+- **PostgreSQL** - Open-source relational database
 - **StarRocks** - High-performance analytical database
 
 ## Enhancements in datus-metricflow
@@ -47,10 +48,9 @@ datus-metricflow currently supports:
 Building on MetricFlow 0.140.0, we have made the following improvements:
 
 - **Python 3.12 Support**: Upgraded to support the latest Python version
-- **Additional Database Support**: Added SQLite and StarRocks adapters
+- **Additional Database Support**: Added SQLite, PostgreSQL and StarRocks adapters
 - **Datus Integration**: Seamlessly integrated with the Datus project for unified configuration
 - **Standalone Package**: Can be installed as a dependency and used independently
-- **MCP Server**: Enables LLM applications to query metrics through the Model Context Protocol
 
 ## Installing datus-metricflow
 

--- a/docs/metricflow/introduction.zh.md
+++ b/docs/metricflow/introduction.zh.md
@@ -39,16 +39,16 @@ MetricFlow 是一层语义层，用于以代码方式组织与管理“业务指
 
 - **DuckDB** — 嵌入式分析数据库（适合本地与 Demo）
 - **SQLite** — 轻量级嵌入式数据库
+- **PostgreSQL** — 开源关系型数据库
 - **StarRocks** — 高性能分析型数据库
 
 ## datus-metricflow 的增强
 在 0.140.0 的基础上，我们提供了：
 
 - **Python 3.12 支持**
-- **新增数据库适配**：SQLite、StarRocks
+- **新增数据库适配**：SQLite、PostgreSQL、StarRocks
 - **与 Datus 集成**：统一配置、无缝协作
 - **独立安装包**：可作为依赖单独使用
-- **MCP 服务器**：通过 Model Context Protocol 让 LLM 应用查询指标
 
 ## 安装
 确保系统已安装 Python 3.12，然后执行：

--- a/docs/subagent/introduction.md
+++ b/docs/subagent/introduction.md
@@ -22,7 +22,7 @@ A **subagent** is a task-specific AI assistant with:
 
 **Use Case**: Convert a database table structure into a YAML semantic model definition.
 
-**Prerequisites**: This subagent relies on [datus-metricflow](../metricflow/introduction.md), install it first.
+**Prerequisites**: This subagent relies on [datus-semantic-metricflow](../adapters/semantic_adapters.md), install it first with `pip install datus-semantic-metricflow`.
 
 **Launch Command**:
 ```bash
@@ -46,7 +46,7 @@ A **subagent** is a task-specific AI assistant with:
 
 **Use Case**: Transform ad-hoc SQL calculations into standardized metrics.
 
-**Prerequisites**: This subagent relies on [datus-metricflow](../metricflow/introduction.md), install it first.
+**Prerequisites**: This subagent relies on [datus-semantic-metricflow](../adapters/semantic_adapters.md), install it first with `pip install datus-semantic-metricflow`.
 
 **Launch Command**:
 ```bash
@@ -180,15 +180,14 @@ agentic_nodes:
     model: claude                          # LLM model
     system_prompt: gen_metrics             # Prompt template name
     prompt_version: "1.0"                  # Template version
-    tools: generation_tools.*, filesystem_tools.*  # Available tools
+    tools: generation_tools.*, filesystem_tools.*, semantic_tools.*  # Available tools
     hooks: generation_hooks                # User confirmation
-    mcp: metricflow_mcp                    # MCP servers
     max_turns: 40                          # Max conversation turns
     workspace_root: /path/to/workspace     # File workspace
     agent_description: "Metric generation assistant"
     rules:                                 # Custom rules
       - Use check_metric_exists to avoid duplicates
-      - Validate with mf validate-configs
+      - Validate with validate_semantic tool
 ```
 
 ### Key Parameters
@@ -198,9 +197,9 @@ agentic_nodes:
 | `model` | Yes | LLM model name | `claude`, `deepseek`, `openai` |
 | `system_prompt` | Yes | Prompt template identifier | `gen_metrics`, `gen_semantic_model` |
 | `prompt_version` | No | Template version | `"1.0"`, `"2.0"` |
-| `tools` | Yes | Comma-separated tool patterns | `db_tools.*, generation_tools.*` |
+| `tools` | Yes | Comma-separated tool patterns | `db_tools.*, semantic_tools.*` |
 | `hooks` | No | Enable confirmation workflow | `generation_hooks` |
-| `mcp` | No | MCP server names | `metricflow_mcp, filesystem_mcp` |
+| `mcp` | No | MCP server names | `filesystem_mcp` |
 | `max_turns` | No | Max conversation turns | `30`, `40` |
 | `workspace_root` | No | File operation directory | `/path/to/workspace` |
 | `agent_description` | No | Assistant description | `"SQL analysis assistant"` |
@@ -224,6 +223,7 @@ tools: db_tools.list_tables, db_tools.get_table_ddl, generation_tools.check_metr
 - `generation_tools.*`: Generation helpers (check duplicates, context preparation)
 - `filesystem_tools.*`: File operations (read, write, edit files)
 - `context_search_tools.*`: Knowledge Base search (find metrics, semantic models)
+- `semantic_tools.*`: Semantic layer operations (list metrics, query metrics, validate)
 - `date_parsing_tools.*`: Date/time parsing and normalization
 
 ### MCP Servers
@@ -233,12 +233,13 @@ MCP (Model Context Protocol) servers provide additional tools:
 **Built-in MCP Servers**:
 
 - `filesystem_mcp`: File system operations within workspace
-- `metricflow_mcp`: MetricFlow CLI integration (validate, query, list)
 
 **Configuration**:
 ```yaml
-mcp: metricflow_mcp, filesystem_mcp
+mcp: filesystem_mcp
 ```
+
+> **Note**: MetricFlow integration is now provided through native `semantic_tools.*` via the [datus-semantic-metricflow](../adapters/semantic_adapters.md) adapter, not through MCP servers.
 
 ## Summary
 

--- a/docs/subagent/introduction.zh.md
+++ b/docs/subagent/introduction.zh.md
@@ -22,7 +22,7 @@ Subagent 是 Datus 中专注于特定任务的专用 AI 助手。与处理通用
 
 **使用场景**：将数据库表结构转换为 YAML 语义模型定义。
 
-**前置条件**：此subagent依赖 [datus-metricflow](../metricflow/introduction.md)，请先安装。
+**前置条件**：此subagent依赖 [datus-semantic-metricflow](../adapters/semantic_adapters.md)，请先运行 `pip install datus-semantic-metricflow` 安装。
 
 **启动命令**：
 ```bash
@@ -46,7 +46,7 @@ Subagent 是 Datus 中专注于特定任务的专用 AI 助手。与处理通用
 
 **使用场景**：将临时 SQL 计算转换为标准化指标。
 
-**前置条件**：此subagent依赖 [datus-metricflow](../metricflow/introduction.md)，请先安装。
+**前置条件**：此subagent依赖 [datus-semantic-metricflow](../adapters/semantic_adapters.md)，请先运行 `pip install datus-semantic-metricflow` 安装。
 
 **启动命令**：
 ```bash
@@ -179,15 +179,14 @@ agentic_nodes:
     model: claude                          # LLM 模型
     system_prompt: gen_metrics             # 提示模板名称
     prompt_version: "1.0"                  # 模板版本
-    tools: generation_tools.*, filesystem_tools.*  # 可用工具
+    tools: generation_tools.*, filesystem_tools.*, semantic_tools.*  # 可用工具
     hooks: generation_hooks                # 用户确认
-    mcp: metricflow_mcp                    # MCP 服务器
     max_turns: 40                          # 最大对话轮数
     workspace_root: /path/to/workspace     # 文件工作空间
     agent_description: "Metric generation assistant"
     rules:                                 # 自定义规则
       - Use check_metric_exists to avoid duplicates
-      - Validate with mf validate-configs
+      - Validate with validate_semantic tool
 ```
 
 ### 关键参数
@@ -197,9 +196,9 @@ agentic_nodes:
 | `model` | 是 | LLM 模型名称 | `claude`、`deepseek`、`openai` |
 | `system_prompt` | 是 | 提示模板标识符 | `gen_metrics`、`gen_semantic_model` |
 | `prompt_version` | 否 | 模板版本 | `"1.0"`、`"2.0"` |
-| `tools` | 是 | 逗号分隔的工具模式 | `db_tools.*, generation_tools.*` |
+| `tools` | 是 | 逗号分隔的工具模式 | `db_tools.*, semantic_tools.*` |
 | `hooks` | 否 | 启用确认工作流 | `generation_hooks` |
-| `mcp` | 否 | MCP 服务器名称 | `metricflow_mcp, filesystem_mcp` |
+| `mcp` | 否 | MCP 服务器名称 | `filesystem_mcp` |
 | `max_turns` | 否 | 最大对话轮数 | `30`、`40` |
 | `workspace_root` | 否 | 文件操作目录 | `/path/to/workspace` |
 | `agent_description` | 否 | 助手描述 | `"SQL analysis assistant"` |
@@ -223,6 +222,7 @@ tools: db_tools.list_tables, db_tools.get_table_ddl, generation_tools.check_metr
 - `generation_tools.*`：生成辅助工具（检查重复、上下文准备）
 - `filesystem_tools.*`：文件操作（读取、写入、编辑文件）
 - `context_search_tools.*`：知识库搜索（查找指标、语义模型）
+- `semantic_tools.*`：语义层操作（列出指标、查询指标、验证）
 - `date_parsing_tools.*`：日期/时间解析和规范化
 
 ### MCP 服务器
@@ -232,12 +232,13 @@ MCP（Model Context Protocol）服务器提供额外工具：
 **内置 MCP 服务器**：
 
 - `filesystem_mcp`：工作空间内的文件系统操作
-- `metricflow_mcp`：MetricFlow CLI 集成（验证、查询、列出）
 
 **配置**：
 ```yaml
-mcp: metricflow_mcp, filesystem_mcp
+mcp: filesystem_mcp
 ```
+
+> **注意**：MetricFlow 集成现在通过 [datus-semantic-metricflow](../adapters/semantic_adapters.md) 适配器提供的原生 `semantic_tools.*` 工具实现，不再使用 MCP 服务器。
 
 ## 总结
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Nodes: configuration/nodes.md
     - Adapters:
       - Database Adapters: adapters/db_adapters.md
+      - Semantic Adapters: adapters/semantic_adapters.md
     - Benchmark:
       - Introduction: benchmark/benchmark_manual.md
     - Metricflow:
@@ -92,6 +93,7 @@ plugins:
             Configuration: 配置
             Adapters: 适配器
             Database Adapters: 数据库适配器
+            Semantic Adapters: 语义层适配器
             Benchmark: 基准测试
             Metricflow: MetricFlow
             Release Notes: 发布说明


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive semantic adapters docs with usage, installation, configuration, and adapter implementation guidance.
  * Added Chinese translation of the semantic adapters docs and updated site navigation to surface the new section.
  * Updated Quickstart, knowledge-base, semantic-model, and subagent docs to reference the semantic adapter package and semantic_tools.*, replacing prior MetricFlow-specific links; MetricFlow docs now list PostgreSQL support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->