### PR TITLE
add metricflow installation in tutorial

### DIFF
--- a/docs/getting_started/Datus_tutorial.md
+++ b/docs/getting_started/Datus_tutorial.md
@@ -18,6 +18,12 @@ Before running the tutorial, initialize your Datus agent:
 datus-agent init
 ```
 
+Since this tutorial involves metric generation, you also need to install the semantic layer adapter:
+
+```bash
+pip install datus-semantic-metricflow
+```
+
 For detailed setup instructions, see the [Quick Start Guide](quickstart.md).
 
 

--- a/docs/getting_started/Datus_tutorial.zh.md
+++ b/docs/getting_started/Datus_tutorial.zh.md
@@ -17,6 +17,12 @@
 datus-agent init
 ```
 
+由于本教程涉及指标生成，还需要安装语义层适配器：
+
+```bash
+pip install datus-semantic-metricflow
+```
+
 详细的设置说明请参见[快速开始指南](quickstart.zh.md)。
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the getting started tutorial in both English and Chinese versions with a new prerequisite note instructing users to install the semantic layer adapter package for metric-generation functionality. The installation step is positioned early in the initial setup sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->