### PR TITLE
fix knowledge bootstrap command

### DIFF
--- a/docs/knowledge_base/ext_knowledge.md
+++ b/docs/knowledge_base/ext_knowledge.md
@@ -26,14 +26,14 @@ Bootstrap-KB External Knowledge is a component that processes, stores, and index
 
 ```bash
 # From CSV (direct import)
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace <your_namespace> \
     --components ext_knowledge \
     --ext_knowledge /path/to/knowledge.csv \
     --kb_update_strategy overwrite
 
 # From success story (AI generation)
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace <your_namespace> \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \
@@ -113,7 +113,7 @@ The success story mode uses GenExtKnowledgeAgenticNode to:
 Clears existing knowledge and loads fresh data:
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --ext_knowledge /path/to/knowledge.csv \
@@ -125,7 +125,7 @@ datus bootstrap-kb \
 Adds new knowledge entries while preserving existing ones (duplicates are skipped):
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \
@@ -139,7 +139,7 @@ Subject tree provides a hierarchical taxonomy for organizing knowledge entries.
 ### 1. Predefined Mode
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \

--- a/docs/knowledge_base/ext_knowledge.zh.md
+++ b/docs/knowledge_base/ext_knowledge.zh.md
@@ -26,14 +26,14 @@ Bootstrap-KB 外部知识是一个处理、存储和索引领域特定业务知�
 
 ```bash
 # 从 CSV（直接导入）
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace <your_namespace> \
     --components ext_knowledge \
     --ext_knowledge /path/to/knowledge.csv \
     --kb_update_strategy overwrite
 
 # 从 success story（AI 生成）
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace <your_namespace> \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \
@@ -113,7 +113,7 @@ success story 模式使用 GenExtKnowledgeAgenticNode 来：
 清除现有知识并加载新数据：
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --ext_knowledge /path/to/knowledge.csv \
@@ -125,7 +125,7 @@ datus bootstrap-kb \
 添加新知识条目同时保留现有条目（重复项会被跳过）：
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \
@@ -139,7 +139,7 @@ datus bootstrap-kb \
 ### 1. 预定义模式
 
 ```bash
-datus bootstrap-kb \
+datus-agent bootstrap-kb \
     --namespace analytics_db \
     --components ext_knowledge \
     --success_story /path/to/success_story.csv \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command references in knowledge base documentation from "datus bootstrap-kb" to "datus-agent bootstrap-kb" across multiple usage examples and configuration scenarios, including CSV import workflows, success story paths, and incremental update strategies.
  * Changes apply to both English and Chinese documentation versions to ensure consistency across the knowledge base.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->